### PR TITLE
新增中心線吸附功能：OnScreenWidgetView 與 LayoutOnScreenControls

### DIFF
--- a/VoidLink/Base.lproj/iPad.storyboard
+++ b/VoidLink/Base.lproj/iPad.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="EVd-wq-ego">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="EVd-wq-ego">
     <device id="ipad11_0rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1410,7 +1410,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fZU-G0-fgM" userLabel="Toolbar Root View" customClass="ToolBarContainerView">
                                 <rect key="frame" x="0.0" y="24" width="1300" height="50"/>
                                 <subviews>
-                                    <stackView autoresizesSubviews="NO" contentMode="scaleToFill" spacing="70" translatesAutoresizingMaskIntoConstraints="NO" id="YLK-IE-ajS">
+                                    <stackView autoresizesSubviews="NO" contentMode="scaleAspectFill" alignment="center" spacing="80" translatesAutoresizingMaskIntoConstraints="NO" id="YLK-IE-ajS">
                                         <rect key="frame" x="235" y="0.0" width="830" height="50"/>
                                         <subviews>
                                             <button autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F7X-l4-cl3" userLabel="Undo">
@@ -1431,7 +1431,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OId-gk-Wkg" userLabel="Load">
-                                                <rect key="frame" x="120" y="0.0" width="50" height="50"/>
+                                                <rect key="frame" x="130" y="0.0" width="50" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="50" id="XlA-qH-mSO"/>
                                                     <constraint firstAttribute="height" constant="50" id="xSe-dW-zjg"/>
@@ -1448,7 +1448,7 @@
                                                 </connections>
                                             </button>
                                             <button autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uda-zt-xrG" userLabel="Save">
-                                                <rect key="frame" x="240" y="0.0" width="50" height="50"/>
+                                                <rect key="frame" x="260" y="0.0" width="50" height="50"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="saveButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="50" id="TEB-dw-YGo"/>
@@ -1466,33 +1466,41 @@
                                                     <action selector="saveTapped:" destination="xSZ-i2-Jts" eventType="touchUpInside" id="bUV-Ja-Htd"/>
                                                 </connections>
                                             </button>
-                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EPu-dl-Tv8">
-                                                <rect key="frame" x="360" y="0.0" width="50" height="50"/>
-                                                <subviews>
-                                                    <button opaque="NO" tag="20" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qJs-n8-eV7" userLabel="Trash">
-                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="50" id="0UR-Tv-X69"/>
-                                                            <constraint firstAttribute="width" constant="50" id="MyN-Qt-jL7"/>
-                                                        </constraints>
-                                                        <color key="tintColor" systemColor="systemTealColor"/>
-                                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                                        <state key="normal">
-                                                            <color key="titleColor" red="0.34534250659999999" green="0.68327885720000003" blue="0.76859849690000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                            <imageReference key="image" image="trash.fill" catalog="system" symbolScale="large"/>
-                                                            <preferredSymbolConfiguration key="preferredSymbolConfiguration" weight="bold"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="trashCanTapped:" destination="xSZ-i2-Jts" eventType="touchUpInside" id="6s3-Wc-6us"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h3G-3j-B2h" userLabel="Magnet">
+                                                <rect key="frame" x="390" y="0.0" width="50" height="50"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="50" id="G6V-W8-Ech"/>
+                                                    <constraint firstAttribute="height" constant="50" id="CfE-ua-tdK"/>
+                                                    <constraint firstAttribute="width" constant="50" id="sWt-Xc-MKG"/>
                                                 </constraints>
-                                            </stackView>
+                                                <color key="tintColor" systemColor="systemTealColor"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal">
+                                                    <imageReference key="image" image="link.circle.fill" catalog="system" symbolScale="large"/>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" weight="bold"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="magnetButtonTapped:" destination="xSZ-i2-Jts" eventType="touchUpInside" id="S8z-zM-ZoG"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" tag="20" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qJs-n8-eV7" userLabel="Trash">
+                                                <rect key="frame" x="520" y="0.0" width="50" height="50"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="50" id="0UR-Tv-X69"/>
+                                                    <constraint firstAttribute="width" constant="50" id="MyN-Qt-jL7"/>
+                                                </constraints>
+                                                <color key="tintColor" systemColor="systemTealColor"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal">
+                                                    <color key="titleColor" red="0.34534250659999999" green="0.68327885720000003" blue="0.76859849690000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    <imageReference key="image" image="trash.fill" catalog="system" symbolScale="large"/>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" weight="bold"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="trashCanTapped:" destination="xSZ-i2-Jts" eventType="touchUpInside" id="6s3-Wc-6us"/>
+                                                </connections>
+                                            </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fKN-ja-TRi" userLabel="Add">
-                                                <rect key="frame" x="480" y="0.0" width="50" height="50"/>
+                                                <rect key="frame" x="650" y="0.0" width="50" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="50" id="g75-DA-uPz"/>
                                                     <constraint firstAttribute="height" constant="50" id="nJF-Od-j7Y"/>
@@ -1509,7 +1517,7 @@
                                                 </connections>
                                             </button>
                                             <button autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="R45-lM-YPl" userLabel="Edit">
-                                                <rect key="frame" x="600" y="0.0" width="230" height="50"/>
+                                                <rect key="frame" x="780" y="0.0" width="50" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="50" id="SpF-xI-pOI"/>
                                                     <constraint firstAttribute="width" constant="50" id="p01-nF-Ee8"/>
@@ -1528,8 +1536,6 @@
                                             </button>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="EPu-dl-Tv8" firstAttribute="centerY" secondItem="YLK-IE-ajS" secondAttribute="centerY" id="9Du-ZM-F8k"/>
-                                            <constraint firstItem="EPu-dl-Tv8" firstAttribute="centerX" secondItem="YLK-IE-ajS" secondAttribute="centerX" id="9ua-n0-eG4"/>
                                             <constraint firstAttribute="width" constant="830" id="zzS-yc-O4H"/>
                                         </constraints>
                                     </stackView>
@@ -1879,6 +1885,7 @@
                         <outlet property="editButton" destination="R45-lM-YPl" id="DNS-7N-3Kh"/>
                         <outlet property="exitButton" destination="7bp-Wn-j9n" id="Kku-3T-RSO"/>
                         <outlet property="loadButton" destination="OId-gk-Wkg" id="adP-54-1ir"/>
+                        <outlet property="magnetButton" destination="h3G-3j-B2h" id="YMh-V7-pKg"/>
                         <outlet property="mouseButtonDownSelector" destination="H8S-aI-EBo" id="em1-fK-Cpb"/>
                         <outlet property="mouseDownButtonStack" destination="GMQ-EQ-Hum" id="sxb-40-3NI"/>
                         <outlet property="saveButton" destination="uda-zt-xrG" id="FyB-WY-rri"/>
@@ -2003,6 +2010,7 @@
         <image name="ChevronCompactUp" width="35" height="10"/>
         <image name="arrow.left.square.fill" catalog="system" width="128" height="114"/>
         <image name="arrow.uturn.backward" width="19.06089973449707" height="18.594499588012695"/>
+        <image name="link.circle.fill" catalog="system" width="128" height="123"/>
         <image name="plus.rectangle.fill.on.rectangle.fill" catalog="system" width="128" height="102"/>
         <image name="rectangle.and.pencil.and.ellipsis" width="36.005599975585938" height="24.95680046081543"/>
         <image name="square.and.arrow.down.fill" catalog="system" width="121" height="128"/>

--- a/VoidLink/Base.lproj/iPhone.storyboard
+++ b/VoidLink/Base.lproj/iPhone.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="DL0-L5-LOv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="DL0-L5-LOv">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,7 +14,7 @@
             <objects>
                 <viewController id="dgh-JZ-Q7z" customClass="MainFrameViewController" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="Rtu-AT-Alw" customClass="AppCollectionView">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="15" minimumInteritemSpacing="15" id="YcZ-cR-3tK">
@@ -81,7 +81,7 @@
             <objects>
                 <navigationController id="ftZ-kC-fxI" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" translucent="NO" id="0ZA-Ec-QgD">
-                        <rect key="frame" x="0.0" y="96" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" red="0.66666668653488159" green="0.66666668653488159" blue="0.66666668653488159" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="barTintColor" red="0.66666668653488159" green="0.66666668653488159" blue="0.66666668653488159" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -162,8 +162,8 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jnu-63-bcf" customClass="ToolBarContainerView">
                                 <rect key="frame" x="0.0" y="0.0" width="1300" height="45"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleAspectFill" alignment="center" spacing="70" translatesAutoresizingMaskIntoConstraints="NO" id="4he-pe-kYB">
-                                        <rect key="frame" x="275" y="0.0" width="750" height="50"/>
+                                    <stackView opaque="NO" contentMode="scaleAspectFill" alignment="center" spacing="66" translatesAutoresizingMaskIntoConstraints="NO" id="4he-pe-kYB">
+                                        <rect key="frame" x="277" y="0.0" width="746" height="50"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pdg-l4-BvF" userLabel="Undo">
                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -183,7 +183,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rXW-Ms-2cJ" userLabel="Load">
-                                                <rect key="frame" x="120" y="0.0" width="50" height="50"/>
+                                                <rect key="frame" x="116" y="0.0" width="50" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="50" id="91g-27-mVH"/>
                                                     <constraint firstAttribute="height" constant="50" id="kRj-b6-Bx1"/>
@@ -199,7 +199,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LPA-ea-YHC" userLabel="Save">
-                                                <rect key="frame" x="240" y="0.0" width="50" height="50"/>
+                                                <rect key="frame" x="232" y="0.0" width="50" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="50" id="Lot-pn-o60"/>
                                                     <constraint firstAttribute="height" constant="50" id="uWO-So-qxr"/>
@@ -214,8 +214,23 @@
                                                     <action selector="saveTapped:" destination="ZYS-Zm-PJs" eventType="touchUpInside" id="cSe-fN-UWC"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QMh-Cg-x2L" userLabel="Magnet">
+                                                <rect key="frame" x="348" y="0.0" width="50" height="50"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="50" id="TGf-ve-MOL"/>
+                                                    <constraint firstAttribute="width" constant="50" id="r7B-zf-SFR"/>
+                                                </constraints>
+                                                <color key="tintColor" systemColor="systemTealColor"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" image="link.circle.fill" catalog="system">
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="25" weight="semibold"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="magnetButtonTapped:" destination="ZYS-Zm-PJs" eventType="touchUpInside" id="H04-ZC-qxQ"/>
+                                                </connections>
+                                            </button>
                                             <button opaque="NO" tag="20" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dhG-Fo-0GK" userLabel="Trash">
-                                                <rect key="frame" x="360" y="0.0" width="50" height="50"/>
+                                                <rect key="frame" x="464" y="0.0" width="50" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="50" id="0vV-wV-Efz"/>
                                                     <constraint firstAttribute="width" constant="50" id="j9W-Ja-bVn"/>
@@ -231,7 +246,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Up4-28-sgF" userLabel="Add">
-                                                <rect key="frame" x="480" y="0.0" width="50" height="50"/>
+                                                <rect key="frame" x="580" y="0.0" width="50" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="50" id="rWU-US-9dl"/>
                                                     <constraint firstAttribute="width" constant="50" id="wWj-wB-MRd"/>
@@ -246,7 +261,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4pE-po-Zn1" userLabel="Edit">
-                                                <rect key="frame" x="600" y="0.0" width="150" height="50"/>
+                                                <rect key="frame" x="696" y="0.0" width="50" height="50"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="50" id="oFn-jm-orG"/>
                                                     <constraint firstAttribute="height" constant="50" id="sls-Vh-uxz"/>
@@ -264,7 +279,7 @@
                                             </button>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="750" id="6BK-sG-WTH"/>
+                                            <constraint firstAttribute="width" constant="746" id="6BK-sG-WTH"/>
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zll-IP-PFt" userLabel="Chevron View">
@@ -668,6 +683,7 @@
                         <outlet property="decelerationRateLabel" destination="znE-Lv-uWV" id="2Ud-O4-DD8"/>
                         <outlet property="decelerationRateSlider" destination="MFc-8O-wdZ" id="8Sh-vO-fqQ"/>
                         <outlet property="decelerationRateStack" destination="3Bf-uN-nLa" id="WaW-YW-Q7p"/>
+                        <outlet property="magnetButton" destination="QMh-Cg-x2L" id="gFr-KF-Ade"/>
                         <outlet property="mouseButtonDownSelector" destination="tE5-Bm-4OB" id="9fh-99-8pu"/>
                         <outlet property="mouseDownButtonStack" destination="lEZ-1a-89J" id="R6t-gC-kcD"/>
                         <outlet property="sensitivityXLabel" destination="dJh-Ck-ugh" id="vso-QW-vxX"/>
@@ -720,12 +736,12 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView opaque="NO" clearsContextBeforeDrawing="NO" alpha="0.5" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="kTH-ez-aKD">
-                                <rect key="frame" x="80" y="112" width="692" height="261"/>
+                                <rect key="frame" x="80" y="64" width="692" height="309"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
                             <navigationBar alpha="0.69999999999999996" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zsA-6X-Qc5">
-                                <rect key="frame" x="80" y="112" width="692" height="44"/>
+                                <rect key="frame" x="80" y="64" width="692" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="R90-2b-UrU"/>
                                 </constraints>
@@ -2031,25 +2047,26 @@
         <image name="ChevronCompactUp" width="35" height="10"/>
         <image name="arrow.left.square.fill" catalog="system" width="128" height="114"/>
         <image name="arrow.uturn.backward" catalog="system" width="128" height="113"/>
+        <image name="link.circle.fill" catalog="system" width="128" height="123"/>
         <image name="plus.rectangle.fill.on.rectangle.fill" catalog="system" width="128" height="102"/>
         <image name="rectangle.and.pencil.and.ellipsis" width="36.005599975585938" height="24.95680046081543"/>
         <image name="square.and.arrow.down.fill" catalog="system" width="121" height="128"/>
         <image name="trash.fill" catalog="system" width="117" height="128"/>
         <image name="tray.full.fill" catalog="system" width="128" height="88"/>
         <systemColor name="linkColor">
-            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondarySystemGroupedBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBrownColor">
-            <color red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGray2Color">
-            <color red="0.68235294120000001" green="0.68235294120000001" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemTealColor">
-            <color red="0.18823529410000001" green="0.69019607839999997" blue="0.78039215689999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.18823529411764706" green="0.69019607843137254" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/VoidLink/Input/CustomOSC/LayoutOnScreenControls.h
+++ b/VoidLink/Input/CustomOSC/LayoutOnScreenControls.h
@@ -35,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event;
 - (void) touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event;
 - (void)updateGuidelinesForOnScreenWidget:(OnScreenWidgetView* )widget;
+- (CGPoint)snappedCenterForOnScreenWidget:(OnScreenWidgetView *)widget
+                            touchLocation:(CGPoint)touchLocation;
 
 @end
 

--- a/VoidLink/Input/CustomOSC/LayoutOnScreenControls.m
+++ b/VoidLink/Input/CustomOSC/LayoutOnScreenControls.m
@@ -216,6 +216,79 @@
     }
 }
 
+- (CGPoint)snappedCenterForLegacyOnScreenControls:(CGPoint)touchLocation{
+    // 讀取閾值（0~15；0=關閉）
+    NSInteger v = [[NSUserDefaults standardUserDefaults] integerForKey:@"OSC_CENTERLINE_SNAP_THRESHOLD"];
+    CGFloat threshold = (CGFloat)MIN(15, MAX(0, v));
+    if (threshold <= 0.0f) {
+        // 不啟用吸附：直接回傳手指位置（已是 superview 座標）
+        return touchLocation;
+    }
+    CGFloat bestDx = threshold + 1.0;
+    CGFloat bestDy = threshold + 1.0;
+    CGFloat snapX = touchLocation.x;
+    CGFloat snapY = touchLocation.y;
+
+    // OSC CALayer
+    for (CALayer *button in self.OSCButtonLayers) {
+        if (!button || button == layerBeingDragged || button.isHidden) continue;
+        CGFloat dx = fabs(touchLocation.x - button.position.x);
+        if (dx <= bestDx) { bestDx = dx; snapX = button.position.x; }
+        CGFloat dy = fabs(touchLocation.y - button.position.y);
+        if (dy <= bestDy) { bestDy = dy; snapY = button.position.y; }
+    }
+
+    // OnScreenWidgetView
+    for (UIView *view in self.layoutToolVC.view.subviews) {
+        if (![view isKindOfClass:[OnScreenWidgetView class]] || view.isHidden) continue;
+        CGFloat dx = fabs(touchLocation.x - view.center.x);
+        if (dx <= bestDx) { bestDx = dx; snapX = view.center.x; }
+        CGFloat dy = fabs(touchLocation.y - view.center.y);
+        if (dy <= bestDy) { bestDy = dy; snapY = view.center.y; }
+    }
+
+    // 套用位置
+    CGPoint snapped = CGPointMake(snapX, snapY);
+    return snapped;
+}
+
+- (CGPoint)snappedCenterForOnScreenWidget:(OnScreenWidgetView *)widget
+                            touchLocation:(CGPoint)touchLocation
+{
+    // 讀取閾值（0~15；0=關閉）
+    NSInteger v = [[NSUserDefaults standardUserDefaults] integerForKey:@"OSC_CENTERLINE_SNAP_THRESHOLD"];
+    CGFloat threshold = (CGFloat)MIN(15, MAX(0, v));
+    if (threshold <= 0.0f) {
+        // 不啟用吸附：直接回傳手指位置（已是 superview 座標）
+        return touchLocation;
+    }
+    CGFloat bestDx = threshold + 1.0;
+    CGFloat bestDy = threshold + 1.0;
+    CGFloat snapX = touchLocation.x;
+    CGFloat snapY = touchLocation.y;
+    
+    // OSC CALayer
+    for (CALayer *button in self.OSCButtonLayers) {
+        if (!button || button.isHidden) continue;
+        CGFloat dx = fabs(touchLocation.x - button.position.x);
+        if (dx <= bestDx) { bestDx = dx; snapX = button.position.x; }
+        CGFloat dy = fabs(touchLocation.y - button.position.y);
+        if (dy <= bestDy) { bestDy = dy; snapY = button.position.y; }
+    }
+
+    // OnScreenWidgetView
+    for(UIView* view in self.layoutToolVC.view.subviews){
+        if (![view isKindOfClass:[OnScreenWidgetView class]] || view == widget || view.isHidden) continue;
+        CGFloat dx = fabs(touchLocation.x - view.center.x);
+        if (dx <= bestDx) { bestDx = dx; snapX = view.center.x; }
+        CGFloat dy = fabs(touchLocation.y - view.center.y);
+        if (dy <= bestDy) { bestDy = dy; snapY = view.center.y; }
+    }
+
+    // 套用位置
+    CGPoint snapped = CGPointMake(snapX, snapY);
+    return snapped;
+}
 
 #pragma mark - Queries
 
@@ -311,48 +384,13 @@
     }
 }
 
-- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+- (void) touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
     UITouch *touch = [touches anyObject];
-    if (!touch) return;
-
-    // 1) 以 _view 為座標系（舊式 OSC 原行為）
     CGPoint touchLocation = [touch locationInView:_view];
-
-    // 2) 中心線吸附：
-    //    候選目標 = 其它 OSC CALayer（self.OSCButtonLayers） + 畫面上的 OnScreenWidgetView
-    CGFloat threshold = 5.0;
-    CGFloat bestDx = threshold + 1.0;
-    CGFloat bestDy = threshold + 1.0;
-    CGFloat snapX = touchLocation.x;
-    CGFloat snapY = touchLocation.y;
-
-    // 2-1) 其它 OSC CALayer
-    for (CALayer *candidate in self.OSCButtonLayers) {
-        if (!candidate || candidate == layerBeingDragged || candidate.isHidden) continue;
-        CGFloat dx = fabs(touchLocation.x - candidate.position.x);
-        if (dx <= bestDx) { bestDx = dx; snapX = candidate.position.x; }
-        CGFloat dy = fabs(touchLocation.y - candidate.position.y);
-        if (dy <= bestDy) { bestDy = dy; snapY = candidate.position.y; }
-    }
-
-    // 2-2) OnScreenWidgetView（從 layoutToolVC.view.subviews 走訪）
-    for (UIView *v in self.layoutToolVC.view.subviews) {
-        if (![v isKindOfClass:[OnScreenWidgetView class]] || v.isHidden) continue;
-        OnScreenWidgetView *w = (OnScreenWidgetView *)v;
-        // 將 widget 的中心轉成 _view 座標（保守處理：若不在同一層，確保座標一致）
-        CGPoint widgetCenterInView = [w.superview convertPoint:w.center toView:_view];
-
-        CGFloat dx = fabs(touchLocation.x - widgetCenterInView.x);
-        if (dx <= bestDx) { bestDx = dx; snapX = widgetCenterInView.x; }
-        CGFloat dy = fabs(touchLocation.y - widgetCenterInView.y);
-        if (dy <= bestDy) { bestDy = dy; snapY = widgetCenterInView.y; }
-    }
-
-    // 3) 套用位置
-    CGPoint snapped = CGPointMake(snapX, snapY);
+    CGPoint snapped = [self snappedCenterForLegacyOnScreenControls:touchLocation];
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    layerBeingDragged.position = snapped;
+    layerBeingDragged.position = snapped; // move object to touch location
     [self updateGuidelinesForLegacyOnScreenControls];
     [CATransaction commit];
 }

--- a/VoidLink/Input/CustomOSC/LayoutOnScreenControls.m
+++ b/VoidLink/Input/CustomOSC/LayoutOnScreenControls.m
@@ -311,12 +311,48 @@
     }
 }
 
-- (void) touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     UITouch *touch = [touches anyObject];
+    if (!touch) return;
+
+    // 1) 以 _view 為座標系（舊式 OSC 原行為）
     CGPoint touchLocation = [touch locationInView:_view];
+
+    // 2) 中心線吸附：
+    //    候選目標 = 其它 OSC CALayer（self.OSCButtonLayers） + 畫面上的 OnScreenWidgetView
+    CGFloat threshold = 5.0;
+    CGFloat bestDx = threshold + 1.0;
+    CGFloat bestDy = threshold + 1.0;
+    CGFloat snapX = touchLocation.x;
+    CGFloat snapY = touchLocation.y;
+
+    // 2-1) 其它 OSC CALayer
+    for (CALayer *candidate in self.OSCButtonLayers) {
+        if (!candidate || candidate == layerBeingDragged || candidate.isHidden) continue;
+        CGFloat dx = fabs(touchLocation.x - candidate.position.x);
+        if (dx <= bestDx) { bestDx = dx; snapX = candidate.position.x; }
+        CGFloat dy = fabs(touchLocation.y - candidate.position.y);
+        if (dy <= bestDy) { bestDy = dy; snapY = candidate.position.y; }
+    }
+
+    // 2-2) OnScreenWidgetView（從 layoutToolVC.view.subviews 走訪）
+    for (UIView *v in self.layoutToolVC.view.subviews) {
+        if (![v isKindOfClass:[OnScreenWidgetView class]] || v.isHidden) continue;
+        OnScreenWidgetView *w = (OnScreenWidgetView *)v;
+        // 將 widget 的中心轉成 _view 座標（保守處理：若不在同一層，確保座標一致）
+        CGPoint widgetCenterInView = [w.superview convertPoint:w.center toView:_view];
+
+        CGFloat dx = fabs(touchLocation.x - widgetCenterInView.x);
+        if (dx <= bestDx) { bestDx = dx; snapX = widgetCenterInView.x; }
+        CGFloat dy = fabs(touchLocation.y - widgetCenterInView.y);
+        if (dy <= bestDy) { bestDy = dy; snapY = widgetCenterInView.y; }
+    }
+
+    // 3) 套用位置
+    CGPoint snapped = CGPointMake(snapX, snapY);
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    layerBeingDragged.position = touchLocation; // move object to touch location
+    layerBeingDragged.position = snapped;
     [self updateGuidelinesForLegacyOnScreenControls];
     [CATransaction commit];
 }

--- a/VoidLink/Input/OnScreenWidgetView.swift
+++ b/VoidLink/Input/OnScreenWidgetView.swift
@@ -1328,31 +1328,79 @@ import UIKit
         }
     }
     
-    private func moveByTouch(touch: UITouch){
-        let currentLocation: CGPoint
-        if OnScreenWidgetView.editMode {currentLocation = touch.location(in: superview)}
-        else {currentLocation = touch.location(in: self)}
-        
-        if !firstTouchMoved {
-            // First move event
-            self.latestTouchLocation = currentLocation
-            self.firstTouchMoved = true
-        }
-                
-        let offsetX = currentLocation.x - latestTouchLocation.x;
-        let offsetY = currentLocation.y - latestTouchLocation.y;
-        
-        let outOfBoundsX = center.x+offsetX >= (self.superview?.bounds.width)! || center.x+offsetX < 0
-        let outOfBoundsY = center.y+offsetY >= (self.superview?.bounds.height)! || center.y+offsetY < 0
+    private func moveByTouch(touch: UITouch) {
+        // --- 取得當幀觸點 ---
+        let touchLocation: CGPoint = OnScreenWidgetView.editMode
+            ? touch.location(in: superview)   // 編輯模式用 superview 座標
+            : touch.location(in: self)        // 非編輯模式維持原行為
 
-        center = CGPoint(x: outOfBoundsX ? center.x : center.x+offsetX, y: outOfBoundsY ? center.y : center.y+offsetY)
-        
-        latestTouchLocation = currentLocation
-        // center = currentLocation;
-        //NSLog("x coord: %f, y coord: %f", self.frame.origin.x, self.frame.origin.y)
-        if OnScreenWidgetView.editMode {
-            guidelineDelegate?.updateGuidelinesForOnScreenWidget(self)
+        // ========== 非編輯模式：維持原 offset 手感（含第一次觸控避跳） ==========
+        if !OnScreenWidgetView.editMode {
+            if !firstTouchMoved {
+                // 第一次 move：記錄基準，避免從 (0,0) 算出巨大 offset 造成「跳一下」
+                self.latestTouchLocation = touchLocation
+                self.firstTouchMoved = true
+                return
+            }
+            // 正常位移：上一幀 → 這一幀
+            let offset = CGPoint(x: touchLocation.x - latestTouchLocation.x,
+                                 y: touchLocation.y - latestTouchLocation.y)
+            center = CGPoint(x: center.x + offset.x, y: center.y + offset.y)
+            latestTouchLocation = touchLocation
+            return
         }
+
+        // ========== 編輯模式：每幀以手指位置為基準 + 中心線吸附 ==========
+        let threshold: CGFloat = 5.0
+
+        // 1) 以手指位置為初始目標
+        var snapX = touchLocation.x
+        var snapY = touchLocation.y
+        var bestDX = threshold + 1.0
+        var bestDY = threshold + 1.0
+
+        // 2) 同容器內其它 Widget 的中心（與 touchLocation 同座標系）
+        if let container = self.superview {
+            for sub in container.subviews {
+                guard let w = sub as? OnScreenWidgetView, w !== self, !w.isHidden else { continue }
+                let dx = abs(touchLocation.x - w.center.x)
+                if dx <= bestDX { bestDX = dx; snapX = w.center.x }
+                let dy = abs(touchLocation.y - w.center.y)
+                if dy <= bestDY { bestDY = dy; snapY = w.center.y }
+            }
+        }
+
+        // 3) 同容器 layer 樹上的 CALayer（例如舊式 OSC 的按鍵）
+        if let containerLayer = self.superview?.layer {
+            func walk(_ layers: [CALayer]?) {
+                guard let layers = layers else { return }
+                for L in layers {
+                    if L === self.layer || L.isHidden { continue }
+                    // 轉成與 touchLocation 相同的容器座標系
+                    let posInContainer = containerLayer.convert(L.position, from: L.superlayer)
+                    let dx = abs(touchLocation.x - posInContainer.x)
+                    if dx <= bestDX { bestDX = dx; snapX = posInContainer.x }
+                    let dy = abs(touchLocation.y - posInContainer.y)
+                    if dy <= bestDY { bestDY = dy; snapY = posInContainer.y }
+                    if let subs = L.sublayers, !subs.isEmpty { walk(subs) }
+                }
+            }
+            walk(containerLayer.sublayers)
+        }
+
+        // 4) 套用（X/Y 各自獨立），並做容器邊界夾制
+        var finalCenter = CGPoint(x: snapX, y: snapY)
+        if let container = superview {
+            let halfW = bounds.width * 0.5
+            let halfH = bounds.height * 0.5
+            finalCenter.x = min(max(finalCenter.x, halfW), max(halfW, container.bounds.width  - halfW))
+            finalCenter.y = min(max(finalCenter.y, halfH), max(halfH, container.bounds.height - halfH))
+        }
+        self.center = finalCenter
+
+        // 5) 更新觸點與指引線（下一幀只要手指離開閾值就會立刻脫離吸附）
+        latestTouchLocation = touchLocation
+        guidelineDelegate?.updateGuidelinesForOnScreenWidget(self)
     }
     
     private func handleControllerTouchesDown(touches: Set<UITouch>) {

--- a/VoidLink/Input/OnScreenWidgetView.swift
+++ b/VoidLink/Input/OnScreenWidgetView.swift
@@ -25,6 +25,15 @@ import UIKit
         func updateGuidelinesForOnScreenWidget(_ sender: Any)
     }
     
+    @objc public weak var snapDelegate: OnScreenWidgetSnapDelegate?
+    
+    @objc public protocol OnScreenWidgetSnapDelegate: AnyObject {
+        /// 根據手指位置計算吸附中心（以 superview 座標系）
+        @objc(snappedCenterForOnScreenWidget:touchLocation:)
+        func snappedCenterForOnScreenWidget(_ widget: OnScreenWidgetView,
+                                            touchLocation: CGPoint) -> CGPoint
+    }
+    
     @objc enum WidgetTypeEnum: UInt8 {
         case uninitialized
         case button
@@ -1328,79 +1337,44 @@ import UIKit
         }
     }
     
-    private func moveByTouch(touch: UITouch) {
-        // --- 取得當幀觸點 ---
-        let touchLocation: CGPoint = OnScreenWidgetView.editMode
-            ? touch.location(in: superview)   // 編輯模式用 superview 座標
-            : touch.location(in: self)        // 非編輯模式維持原行為
-
-        // ========== 非編輯模式：維持原 offset 手感（含第一次觸控避跳） ==========
+    private func moveByTouch(touch: UITouch){
+        let currentLocation: CGPoint
+        if OnScreenWidgetView.editMode {currentLocation = touch.location(in: superview)}
+        else {currentLocation = touch.location(in: self)}
+        
         if !OnScreenWidgetView.editMode {
             if !firstTouchMoved {
-                // 第一次 move：記錄基準，避免從 (0,0) 算出巨大 offset 造成「跳一下」
-                self.latestTouchLocation = touchLocation
+                // First move event
+                self.latestTouchLocation = currentLocation
                 self.firstTouchMoved = true
-                return
             }
-            // 正常位移：上一幀 → 這一幀
-            let offset = CGPoint(x: touchLocation.x - latestTouchLocation.x,
-                                 y: touchLocation.y - latestTouchLocation.y)
-            center = CGPoint(x: center.x + offset.x, y: center.y + offset.y)
-            latestTouchLocation = touchLocation
+                    
+            let offsetX = currentLocation.x - latestTouchLocation.x;
+            let offsetY = currentLocation.y - latestTouchLocation.y;
+            
+            let outOfBoundsX = center.x+offsetX >= (self.superview?.bounds.width)! || center.x+offsetX < 0
+            let outOfBoundsY = center.y+offsetY >= (self.superview?.bounds.height)! || center.y+offsetY < 0
+
+            center = CGPoint(x: outOfBoundsX ? center.x : center.x+offsetX, y: outOfBoundsY ? center.y : center.y+offsetY)
+            
+            latestTouchLocation = currentLocation
+            // center = currentLocation;
+            //NSLog("x coord: %f, y coord: %f", self.frame.origin.x, self.frame.origin.y)
             return
         }
 
-        // ========== 編輯模式：每幀以手指位置為基準 + 中心線吸附 ==========
-        let threshold: CGFloat = 5.0
-
-        // 1) 以手指位置為初始目標
-        var snapX = touchLocation.x
-        var snapY = touchLocation.y
-        var bestDX = threshold + 1.0
-        var bestDY = threshold + 1.0
-
-        // 2) 同容器內其它 Widget 的中心（與 touchLocation 同座標系）
-        if let container = self.superview {
-            for sub in container.subviews {
-                guard let w = sub as? OnScreenWidgetView, w !== self, !w.isHidden else { continue }
-                let dx = abs(touchLocation.x - w.center.x)
-                if dx <= bestDX { bestDX = dx; snapX = w.center.x }
-                let dy = abs(touchLocation.y - w.center.y)
-                if dy <= bestDY { bestDY = dy; snapY = w.center.y }
+        // 容器邊界夾制與中心線吸附
+        if var finalCenter = snapDelegate?.snappedCenterForOnScreenWidget(self, touchLocation: currentLocation) {
+            if let container = superview {
+                let halfW = bounds.width * 0.5
+                let halfH = bounds.height * 0.5
+                finalCenter.x = min(max(finalCenter.x, halfW), max(halfW, container.bounds.width  - halfW))
+                finalCenter.y = min(max(finalCenter.y, halfH), max(halfH, container.bounds.height - halfH))
             }
+            self.center = finalCenter
+            latestTouchLocation = currentLocation
+            guidelineDelegate?.updateGuidelinesForOnScreenWidget(self)
         }
-
-        // 3) 同容器 layer 樹上的 CALayer（例如舊式 OSC 的按鍵）
-        if let containerLayer = self.superview?.layer {
-            func walk(_ layers: [CALayer]?) {
-                guard let layers = layers else { return }
-                for L in layers {
-                    if L === self.layer || L.isHidden { continue }
-                    // 轉成與 touchLocation 相同的容器座標系
-                    let posInContainer = containerLayer.convert(L.position, from: L.superlayer)
-                    let dx = abs(touchLocation.x - posInContainer.x)
-                    if dx <= bestDX { bestDX = dx; snapX = posInContainer.x }
-                    let dy = abs(touchLocation.y - posInContainer.y)
-                    if dy <= bestDY { bestDY = dy; snapY = posInContainer.y }
-                    if let subs = L.sublayers, !subs.isEmpty { walk(subs) }
-                }
-            }
-            walk(containerLayer.sublayers)
-        }
-
-        // 4) 套用（X/Y 各自獨立），並做容器邊界夾制
-        var finalCenter = CGPoint(x: snapX, y: snapY)
-        if let container = superview {
-            let halfW = bounds.width * 0.5
-            let halfH = bounds.height * 0.5
-            finalCenter.x = min(max(finalCenter.x, halfW), max(halfW, container.bounds.width  - halfW))
-            finalCenter.y = min(max(finalCenter.y, halfH), max(halfH, container.bounds.height - halfH))
-        }
-        self.center = finalCenter
-
-        // 5) 更新觸點與指引線（下一幀只要手指離開閾值就會立刻脫離吸附）
-        latestTouchLocation = touchLocation
-        guidelineDelegate?.updateGuidelinesForOnScreenWidget(self)
     }
     
     private func handleControllerTouchesDown(touches: Set<UITouch>) {

--- a/VoidLink/Localization/Localizable.xcstrings
+++ b/VoidLink/Localization/Localizable.xcstrings
@@ -1048,6 +1048,29 @@
         }
       }
     },
+    "Center Line Snapping" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中心线吸附"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中心線吸附"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中心線吸附"
+          }
+        }
+      }
+    },
     "Check the command and parameter." : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3278,6 +3301,29 @@
         }
       }
     },
+    "Off" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
+          }
+        }
+      }
+    },
     "Offline" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5117,6 +5163,29 @@
         }
       }
     },
+    "Strong Snap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "强磁铁"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強磁鐵"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強磁鐵"
+          }
+        }
+      }
+    },
     "Successfully sent wake-up request. It may take a few moments for the PC to wake. If it never wakes up, ensure it's properly configured for Wake-on-LAN." : {
       "extractionState" : "manual",
       "localizations" : {
@@ -5865,6 +5934,29 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "聯絡開發者 True砖家"
+          }
+        }
+      }
+    },
+    "Weak Snap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "弱磁铁"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "弱磁鐵"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "弱磁鐵"
           }
         }
       }

--- a/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.h
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.h
@@ -64,6 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UIButton *addButton;
 @property (weak, nonatomic) IBOutlet UIButton *editButton;
 
+@property (weak, nonatomic) IBOutlet UIButton *magnetButton;
+
 
 
 

--- a/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.m
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.m
@@ -19,6 +19,8 @@
 #import "ThemeManager.h"
 #import "DataManager.h"
 
+#define OSC_CENTERLINE_SNAP_THRESHOLD @"OSC_CENTERLINE_SNAP_THRESHOLD"
+
 @interface LayoutOnScreenControlsViewController ()
 
 @end
@@ -191,6 +193,11 @@
     [self addInnerAnalogSticksToOuterAnalogLayers]; // allows inner and analog sticks to be dragged together around the screen together as one unit which is the expected behavior
     
     self.undoButton.alpha = 0.3;    // no changes to undo yet, so fade out the undo button a bit
+    
+    // 設定預設值：第一次啟動沒有設定時給 5
+    if ([[NSUserDefaults standardUserDefaults] objectForKey:OSC_CENTERLINE_SNAP_THRESHOLD] == nil) {
+        [[NSUserDefaults standardUserDefaults] setInteger:5 forKey:OSC_CENTERLINE_SNAP_THRESHOLD];
+    }
     
     NSMutableArray* allProfiles = [profilesManager getAllProfiles];
     /*
@@ -1054,6 +1061,7 @@
                 if(button==_loadButton) [button setTitle:[LocalizationHelper localizedStringForKey:@"Load"] forState:UIControlStateNormal];
                 if(button==_addButton) [button setTitle:[LocalizationHelper localizedStringForKey:@"Add"] forState:UIControlStateNormal];
                 if(button==_editButton) [button setTitle:[LocalizationHelper localizedStringForKey:@"Edit"] forState:UIControlStateNormal];
+                if(button==_magnetButton) [button setTitle:[LocalizationHelper localizedStringForKey:@"Snap"] forState:UIControlStateNormal];
 
             }
         }
@@ -1318,6 +1326,76 @@
     [self presentProfilesTableView];
 }
 
+- (IBAction)magnetButtonTapped:(id)sender {
+    NSInteger current = [[NSUserDefaults standardUserDefaults] integerForKey:OSC_CENTERLINE_SNAP_THRESHOLD];
+    NSInteger normalized = (current == 0 ? 0 : (current >= 15 ? 15 : 5));
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:[LocalizationHelper localizedStringForKey:@"Center Line Snapping"]
+                                                                   message:nil
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+
+    // 內容 VC：用來放 segmented control，避免和標題重疊，並能加內距
+    UIViewController *contentVC = [[UIViewController alloc] init];
+    contentVC.view.translatesAutoresizingMaskIntoConstraints = NO;
+    contentVC.preferredContentSize = CGSizeMake(270, 48); // 讓 alert 有合適高度
+
+    // 容器：用 layoutMargins 提供與視窗邊緣的空間
+    UIView *container = [[UIView alloc] init];
+    container.translatesAutoresizingMaskIntoConstraints = NO;
+    container.layoutMargins = UIEdgeInsetsMake(0, 8, 16, 8); // 上下左右留白
+    [contentVC.view addSubview:container];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [container.topAnchor constraintEqualToAnchor:contentVC.view.topAnchor],
+        [container.leadingAnchor constraintEqualToAnchor:contentVC.view.leadingAnchor],
+        [container.trailingAnchor constraintEqualToAnchor:contentVC.view.trailingAnchor],
+        [container.bottomAnchor constraintEqualToAnchor:contentVC.view.bottomAnchor],
+    ]];
+
+    // Segmented control：禁用 / 弱磁鐵 / 強磁鐵 -> 0 / 5 / 15
+    UISegmentedControl *seg = [[UISegmentedControl alloc] initWithItems:@[
+        [LocalizationHelper localizedStringForKey:@"Off"],
+        [LocalizationHelper localizedStringForKey:@"Weak Snap"],
+        [LocalizationHelper localizedStringForKey:@"Strong Snap"]
+    ]];
+    seg.translatesAutoresizingMaskIntoConstraints = NO;
+    seg.selectedSegmentIndex = (normalized == 0 ? 0 : (normalized >= 15 ? 2 : 1));
+    seg.apportionsSegmentWidthsByContent = NO;
+
+    [container addSubview:seg];
+
+    // 讓 segmented control 依 margins 置中並留白
+    UILayoutGuide *m = container.layoutMarginsGuide;
+    [NSLayoutConstraint activateConstraints:@[
+        [seg.topAnchor constraintEqualToAnchor:m.topAnchor],
+        [seg.leadingAnchor constraintEqualToAnchor:m.leadingAnchor],
+        [seg.trailingAnchor constraintEqualToAnchor:m.trailingAnchor],
+        [seg.bottomAnchor constraintEqualToAnchor:m.bottomAnchor],
+        // 最小高度，避免過扁
+        [seg.heightAnchor constraintGreaterThanOrEqualToConstant:32.0]
+    ]];
+
+    // 把內容 VC 正式放進 Alert（這招可避免與標題重疊）
+    [alert setValue:contentVC forKey:@"contentViewController"];
+
+    [alert addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Cancel"]
+                                              style:UIAlertActionStyleCancel
+                                            handler:nil]];
+
+    [alert addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"OK"]
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(__unused UIAlertAction *action) {
+        NSInteger value = 5;
+        switch (seg.selectedSegmentIndex) {
+            case 0: value = 0;  break; // 禁用
+            case 1: value = 5;  break; // 弱磁鐵
+            case 2: value = 15; break; // 強磁鐵
+        }
+        [[NSUserDefaults standardUserDefaults] setInteger:value forKey:OSC_CENTERLINE_SNAP_THRESHOLD];
+    }]];
+
+    [self presentViewController:alert animated:YES completion:nil];
+}
 
 #pragma mark - Touch
 


### PR DESCRIPTION
功能內容

1. 中心線對齊吸附
在編輯模式中拖曳時，當控件中心線與其他控件（或舊版控件）中心線在 ±5pt 範圍內時，會自動吸附。
X、Y 軸獨立判斷，確保吸附行為自然。

2. 雙向吸附
新版控件與舊版控件也可以相互吸附。

2. 脫離判斷一致化
與舊式 OSC 相同：只要手指離開對齊線超過閾值，下一幀立即脫離吸附。
避免了 Swift 端原本 offset 累加帶來的「黏性」問題。