### PR TITLE
实时窗口适配功能

### DIFF
--- a/VoidLink/Stream/VideoDecoderRenderer.m
+++ b/VoidLink/Stream/VideoDecoderRenderer.m
@@ -25,6 +25,7 @@
 #include <libavformat/avio.h>
 #include <libavutil/mem.h>
 #include <mach/mach_time.h>
+#include <math.h>
 
 // Define for extra logging related to frame pacing
 //#define DISPLAYLINK_VERBOSE
@@ -72,12 +73,25 @@ extern int ff_isom_write_av1c(AVIOContext *pb, const uint8_t *buf, int size,
     // respects the PAR encoded in the SPS which causes our computed video-relative
     // touch location to be wrong in StreamView if the aspect ratio of the host
     // desktop doesn't match the aspect ratio of the stream.
-    CGSize videoSize;
-    if (_view.bounds.size.width > _view.bounds.size.height * _streamAspectRatio) {
-        videoSize = CGSizeMake(_view.bounds.size.height * _streamAspectRatio, _view.bounds.size.height);
-    } else {
-        videoSize = CGSizeMake(_view.bounds.size.width, _view.bounds.size.width / _streamAspectRatio);
+    // Compute a safe aspect ratio and video size to avoid NaN/Inf bounds
+    CGFloat viewW = _view.bounds.size.width;
+    CGFloat viewH = _view.bounds.size.height;
+    float ar = _streamAspectRatio;
+    if (!isfinite(ar) || ar <= 0.0f) {
+        if (viewH > 0.0) ar = (float)(viewW / viewH);
+        if (!isfinite(ar) || ar <= 0.0f) ar = 16.0f/9.0f;
     }
+    if (!(viewW > 0.0)) viewW = 1.0;
+    if (!(viewH > 0.0)) viewH = 1.0;
+
+    CGSize videoSize;
+    if (viewW > viewH * ar) {
+        videoSize = CGSizeMake(viewH * ar, viewH);
+    } else {
+        videoSize = CGSizeMake(viewW, viewW / ar);
+    }
+    if (!isfinite(videoSize.width) || videoSize.width <= 0.0) videoSize.width = MAX(viewW, 1.0);
+    if (!isfinite(videoSize.height) || videoSize.height <= 0.0) videoSize.height = MAX(viewH, 1.0);
 
     [CATransaction begin];
     [CATransaction setDisableActions:YES];

--- a/VoidLink/ViewControllers/MainFrameViewController.h
+++ b/VoidLink/ViewControllers/MainFrameViewController.h
@@ -36,6 +36,9 @@
 - (bool)isIPhonePortrait;
 - (void)quitRunningApp;
 - (NSInteger)requestForBitrate:(NSInteger)bitrateKbps;
+// Resume the currently running app (if any) immediately, using
+// updated resolution derived from current window metrics.
+- (void)resumeRunningAppAfterResize;
 #endif
 - (void)fillResolutionTable:(CGSize*)resolutionTable externalDisplayMode:(NSInteger)externalDisplayMode;
 - (bool)isIPhone;

--- a/VoidLink/ViewControllers/MainFrameViewController.m
+++ b/VoidLink/ViewControllers/MainFrameViewController.m
@@ -85,6 +85,14 @@
 }
 static NSMutableSet* hostList;
 
+- (void)onRealtimeAdaptationResumeRequest:(NSNotification *)note {
+    [self resumeRunningAppAfterResize];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLRealtimeAdaptationResumeRequest" object:nil];
+}
+
 - (void)startPairing:(NSString *)PIN {
     // Needs to be synchronous to ensure the alert is shown before any potential
     // failure callback could be invoked.
@@ -100,6 +108,80 @@ static NSMutableSet* hostList;
             }];
         }]];
         [[self activeViewController] presentViewController:self->_pairAlert animated:YES completion:nil];
+    });
+}
+
+- (void)resumeRunningAppAfterResize {
+    static int s_autoAdaptResumeTries = 0;
+    static BOOL s_autoAdaptResumeInFlight = NO;
+    if (s_autoAdaptResumeInFlight) {
+        Log(LOG_W, @"[Auto-Adapt] Resume already in flight; ignoring duplicate request");
+        return;
+    }
+    Log(LOG_I, @"[Auto-Adapt] Resume request received (try %d)", s_autoAdaptResumeTries + 1);
+    // Find a host with a running app. Prefer the selected host if set.
+    TemporaryHost *host = _selectedHost;
+    if (host == nil && hostList.count > 0) {
+        for (TemporaryHost *h in hostList) {
+            if (h.currentGame && ![h.currentGame isEqualToString:@"0"]) {
+                host = h;
+                break;
+            }
+        }
+    }
+    if (host == nil) {
+        Log(LOG_W, @"[Auto-Adapt] No host available to resume after resize");
+        if (s_autoAdaptResumeTries++ < 5) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                [self resumeRunningAppAfterResize];
+            });
+        } else {
+            s_autoAdaptResumeTries = 0;
+        }
+        return;
+    }
+    // Ensure updateAppsForHost: doesn't early-return
+    _selectedHost = host;
+    TemporaryApp *currentApp = [self findRunningApp:host];
+    if (currentApp == nil && launchedApp != nil) {
+        // Fallback to previously launched app if discovery hasn't populated yet
+        Log(LOG_I, @"[Auto-Adapt] Using previously launched app: %@", launchedApp.name);
+        currentApp = launchedApp;
+    }
+    if (currentApp == nil) {
+        // Fallback: ensure app list is up-to-date and pick the first app
+        [self updateAppsForHost:host];
+        if (host.appList.count == 0) {
+            Log(LOG_W, @"[Auto-Adapt] No apps on host; will retry");
+            if (s_autoAdaptResumeTries++ < 5) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [self resumeRunningAppAfterResize];
+                });
+            } else {
+                s_autoAdaptResumeTries = 0;
+            }
+            return;
+        }
+        if (_sortedAppList != nil && _sortedAppList.count > 0) {
+            currentApp = _sortedAppList.firstObject;
+        }
+        if (currentApp == nil) {
+            NSArray *apps = [host.appList allObjects];
+            if (apps.count > 0) {
+                currentApp = apps.firstObject;
+            }
+        }
+    }
+
+    // Prepare stream config (includes resolution update based on window)
+    Log(LOG_I, @"[Auto-Adapt] Resuming app: %@", currentApp.name);
+    s_autoAdaptResumeInFlight = YES;
+    [self prepareToStreamApp:currentApp];
+    [self performSegueWithIdentifier:@"createStreamFrame" sender:nil];
+    s_autoAdaptResumeTries = 0;
+    // Clear in-flight flag after a short grace period to allow future auto-adapt cycles
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        s_autoAdaptResumeInFlight = NO;
     });
 }
 
@@ -1534,6 +1616,9 @@ static NSMutableSet* hostList;
     DataManager* dataMan = [[DataManager alloc] init];
     TemporarySettings* tempSettings = [dataMan getSettings];
     [ThemeManager setUserInterfaceStyle:tempSettings.appTheme.intValue];
+    // Listen for real-time adaptation resume requests
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onRealtimeAdaptationResumeRequest:) name:@"VLRealtimeAdaptationResumeRequest" object:nil];
+    Log(LOG_I, @"[Auto-Adapt] Observer registered on MainFrameViewController");
     
 #if !TARGET_OS_TV
     self.settingsExpandedInStreamView = false; // init this flag

--- a/VoidLink/ViewControllers/SettingsViewController.h
+++ b/VoidLink/ViewControllers/SettingsViewController.h
@@ -62,6 +62,10 @@
 @property (strong, nonatomic) IBOutlet UIStackView *frameQueueSizeStack;
 @property (strong, nonatomic) IBOutlet UIStackView *performanceGraphStack;
 
+// Programmatic: Real-time window adaptation toggle (under Video section, below PiP)
+@property (strong, nonatomic) UIStackView *realtimeAdaptationStack;
+@property (strong, nonatomic) UISwitch *realtimeAdaptationSwitch;
+
 @property (strong, nonatomic) IBOutlet UILabel *bitrateLabel;
 @property (strong, nonatomic) IBOutlet UISlider *bitrateSlider;
 @property (strong, nonatomic) IBOutlet UISegmentedControl *framerateSelector;

--- a/VoidLink/ViewControllers/SettingsViewController.m
+++ b/VoidLink/ViewControllers/SettingsViewController.m
@@ -718,6 +718,33 @@ BOOL isCustomResolution(int resolutionSelected) {
     [self addSetting:self.hdrStack ofId:@"hdrStack" withInfoTag:![self hdrSupported] withDynamicLabel:NO to:videoSection];
     [self addSetting:self.yuv444Stack ofId:@"yuv444Stack" withInfoTag:YES withDynamicLabel:NO to:videoSection];
     [self addSetting:self.pipStack ofId:@"pipStack" withInfoTag:YES withDynamicLabel:NO to:videoSection];
+    
+    // Add "Real-time window adaptation" toggle below PiP
+    if (!self.realtimeAdaptationStack) {
+        UILabel *label = [[UILabel alloc] init];
+        label.text = [LocalizationHelper localizedStringForKey:@"Real-time window adaptation"];
+        label.textColor = [UIColor labelColor];
+        label.numberOfLines = 1;
+        
+        self.realtimeAdaptationSwitch = [[UISwitch alloc] init];
+        BOOL rtEnabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"VLRealtimeWindowAdaptationEnabled"];
+        self.realtimeAdaptationSwitch.on = rtEnabled;
+        [self.realtimeAdaptationSwitch addTarget:self action:@selector(realtimeAdaptationSwitchFlipped:) forControlEvents:UIControlEventValueChanged];
+        
+        UIStackView *row = [[UIStackView alloc] initWithArrangedSubviews:@[label, self.realtimeAdaptationSwitch]];
+        row.axis = UILayoutConstraintAxisHorizontal;
+        row.alignment = UIStackViewAlignmentCenter;
+        row.distribution = UIStackViewDistributionFill;
+        row.spacing = 8.0;
+        row.translatesAutoresizingMaskIntoConstraints = NO;
+        
+        // Hugging/compression priorities to keep switch at right
+        [label setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+        [self.realtimeAdaptationSwitch setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+        
+        self.realtimeAdaptationStack = row;
+    }
+    [self addSetting:self.realtimeAdaptationStack ofId:@"realtimeAdaptationStack" withInfoTag:NO withDynamicLabel:NO to:videoSection];
     [self addSetting:self.framePacingStack ofId:@"framePacingStack" withInfoTag:YES withDynamicLabel:NO to:videoSection];
     [self addSetting:self.frameQueueSizeStack ofId:@"frameQueueSizeStack" withInfoTag:NO withDynamicLabel:YES to:videoSection];
 
@@ -867,6 +894,13 @@ BOOL isCustomResolution(int resolutionSelected) {
     
     [experimentalSection addToParentStack:_parentStack];
     // [experimentalSection setExpanded:NO];
+}
+
+#pragma mark - Real-time window adaptation
+
+- (void)realtimeAdaptationSwitchFlipped:(UISwitch* )sender {
+    [[NSUserDefaults standardUserDefaults] setBool:sender.isOn forKey:@"VLRealtimeWindowAdaptationEnabled"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 

--- a/VoidLink/ViewControllers/StreamFrameViewController.m
+++ b/VoidLink/ViewControllers/StreamFrameViewController.m
@@ -81,6 +81,11 @@
     BOOL _isRestoringFromPiP;
     CADisplayLink *_displayLink;
 
+    // Real-time window adaptation state
+    dispatch_block_t _autoAdaptQuitResumeBlock;
+    BOOL _autoAdaptQuitResumeInProgress;
+    
+
 #if !TARGET_OS_TV
     CustomEdgeSlideGestureRecognizer *_slideToSettingsRecognizer;
     CustomEdgeSlideGestureRecognizer *_slideToToolboxRecognizer;
@@ -693,6 +698,16 @@
                                                  name:@"OscLayoutCloseNotification"
                                                object:nil];
 
+    // Observe Menu Bar (iOS 18+) button actions via notifications
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(expandSettingsView)
+                                                 name:@"VLMenuBarOpenSettings"
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(bringUpToolboxMenu)
+                                                 name:@"VLMenuBarOpenToolbox"
+                                               object:nil];
+
 #if 0
     // FIXME: This doesn't work reliably on iPad for some reason. Showing and hiding the keyboard
     // several times in a row will not correctly restore the state of the UIScrollView.
@@ -1161,6 +1176,8 @@
 - (void) connectionStarted {
     Log(LOG_I, @"Connection started");
     dispatch_async(dispatch_get_main_queue(), ^{
+        //
+
         // Leave the spinner spinning until it's obscured by
         // the first frame of video.
         self->_stageLabel.hidden = YES;
@@ -1192,6 +1209,8 @@
 
 - (void)connectionTerminated:(int)errorCode {
     Log(LOG_I, @"Connection terminated: %d", errorCode);
+
+    // orderly-termination branch removed
     
     unsigned int portFlags = LiGetPortFlagsFromTerminationErrorCode(errorCode);
     unsigned int portTestResults = LiTestClientConnectivity(CONN_TEST_SERVER, 443, portFlags);
@@ -1631,7 +1650,7 @@
         return;
     }
 
-    Log(LOG_I, @"View size changed, terminating stream");
+    Log(LOG_I, @"View size changed, reconfiguring");
     
     double delayInSeconds = 0.2;
     if (_delayedRemoveExtScreen) {
@@ -1639,15 +1658,26 @@
     }
     dispatch_block_t block = dispatch_block_create(0, ^{
         [self handleViewResize];
-        [self reConfigStreamViewRealtimeAndReloadSettings:YES];
+        // Avoid heavy reconfiguration when real-time adaptation is enabled;
+        // the stream will be restarted shortly with the new resolution.
+        if (![self isRealtimeAdaptationEnabled]) {
+            [self reConfigStreamViewRealtimeAndReloadSettings:YES];
+        }
     });
     _delayedRemoveExtScreen = block;
     dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
     dispatch_after(delayTime, dispatch_get_main_queue(), block);
+
+    // Real-time adaptation: simple return-and-resume after stabilization
+    if ([self isRealtimeAdaptationEnabled] && !_autoAdaptQuitResumeInProgress) {
+        [self scheduleAutoAdaptQuitAndResumeWithDelay:0];
+    }
 }
 
 - (void)dealloc {
     [self stopDisplayLink];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLMenuBarOpenSettings" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLMenuBarOpenToolbox" object:nil];
 }
 
 - (void)setupDisplayLink {
@@ -1670,6 +1700,88 @@
         LiSendKeyboardEvent(0xFF, KEY_ACTION_UP, 0);
     });
 }
+
+
+#pragma mark - Real-time Window Adaptation
+
+- (BOOL)isRealtimeAdaptationEnabled {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"VLRealtimeWindowAdaptationEnabled"];
+}
+
+- (void)setRealtimeAdaptationEnabled:(BOOL)enabled {
+    [[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"VLRealtimeWindowAdaptationEnabled"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (void)toggleRealtimeAdaptation {
+    BOOL enabled = ![self isRealtimeAdaptationEnabled];
+    [self setRealtimeAdaptationEnabled:enabled];
+    Log(LOG_I, @"Real-time window adaptation: %s", enabled ? "ON" : "OFF");
+    NSString *msg = enabled ? @"Real-time window adaptation: ON" : @"Real-time window adaptation: OFF";
+    [self updateOverlayText:msg];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self updateOverlayText:nil];
+    });
+}
+
+- (void)scheduleAutoAdaptQuitAndResumeWithDelay:(NSTimeInterval)delaySeconds {
+    if (_autoAdaptQuitResumeInProgress) {
+        return;
+    }
+    if (_autoAdaptQuitResumeBlock) {
+        dispatch_block_cancel(_autoAdaptQuitResumeBlock);
+        _autoAdaptQuitResumeBlock = nil;
+    }
+    __weak typeof(self) weakSelf = self;
+    dispatch_block_t block = dispatch_block_create(0, ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf performAutoAdaptQuitAndResume];
+    });
+    _autoAdaptQuitResumeBlock = block;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delaySeconds * NSEC_PER_SEC)), dispatch_get_main_queue(), block);
+}
+
+- (void)performAutoAdaptQuitAndResume {
+    if (_autoAdaptQuitResumeInProgress) return;
+    _autoAdaptQuitResumeInProgress = YES;
+
+    // Return to main frame, then instruct it to resume the running app.
+    // We dispatch the resume after a slight delay to ensure navigation popped.
+    [self returnToMainFrame];
+    // Defer resume to MainFrameViewController via notification to avoid timing/ownership issues
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        Log(LOG_I, @"[Auto-Adapt] Posting resume request notification");
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"VLRealtimeAdaptationResumeRequest" object:nil];
+        // Also directly invoke on MainFrame to be robust against notification timing
+        if (self.mainFrameViewcontroller && [self.mainFrameViewcontroller respondsToSelector:@selector(resumeRunningAppAfterResize)]) {
+            Log(LOG_I, @"[Auto-Adapt] Direct resume invoke on MainFrameViewController");
+            [self.mainFrameViewcontroller resumeRunningAppAfterResize];
+        }
+        self->_autoAdaptQuitResumeInProgress = NO;
+    });
+}
+
+- (CGSize)currentWindowPixelSize {
+    UIWindow *window = _deviceWindow ? _deviceWindow : self.view.window;
+    if (!window) {
+        UIScreen *screen = [UIScreen mainScreen];
+        return CGSizeMake(self.view.bounds.size.width * screen.scale,
+                          self.view.bounds.size.height * screen.scale);
+    }
+    CGFloat scale = window.screen.scale;
+    CGFloat w = window.frame.size.width * scale;
+    CGFloat h = window.frame.size.height * scale;
+    if (UIScreen.screens.count > 1 && [self isAirPlayEnabled]) {
+        CGRect bounds = [UIScreen.screens.lastObject bounds];
+        scale = [UIScreen.screens.lastObject scale];
+        w = bounds.size.width * scale;
+        h = bounds.size.height * scale;
+    }
+    return CGSizeMake(w, h);
+}
+
+// removed old in-place restart path (scheduleAutoAdaptRestartWithDelay / performAutoAdaptRestart)
 
 
 @end


### PR DESCRIPTION
# 实时窗口适配功能

## 功能概述
实现自适应窗口功能，允许用户在流媒体播放过程中实时调整窗口尺寸，自动重新配置流媒体分辨率以匹配新的窗口大小。

## 主要特性

### ✨ 核心功能
- **实时窗口适配**：窗口尺寸变化时自动调整视频分辨率
- **用户可控开关**：在设置-视频部分提供实时窗口适配开关
- **智能重启机制**：窗口稳定后自动重新连接流媒体
- **防崩溃保护**：增强的参数校验，防止 NaN/Inf 导致的计算错误

### 🔧 技术实现

#### VideoDecoderRenderer.m - 安全计算逻辑
```objective-c
// 添加了完整的参数校验，防止异常值
CGFloat viewW = _view.bounds.size.width;
CGFloat viewH = _view.bounds.size.height;
float ar = _streamAspectRatio;
if (!isfinite(ar) || ar <= 0.0f) {
    // 安全回退机制
}
```

#### SettingsViewController.m - UI控制
- 在PiP设置下方添加实时窗口适配开关
- 使用NSUserDefaults持久化用户偏好
- 实时响应用户设置变化

#### StreamFrameViewController.m - 智能状态管理
- 防重入保护机制
- 异步操作管理
- 双重通知机制确保可靠性

#### MainFrameViewController.m - 健壮重启流程
- 多重重试机制（最多5次）
- 智能主机和应用发现
- 渐进式回退策略

## ⚠️ 重要安全警告

**⚠️ 如果改变窗口操作间隔过短应用可能会崩！**

### 使用注意事项：
- 🚫 **避免快速连续调整窗口尺寸**
- ⏱️ **建议每次调整间隔至少1-2秒**
- 🔧 **在设置中可以随时关闭此功能**
- 📱 **建议在稳定的网络环境下使用**

## 代码变更文件
- `VoidLink/Stream/VideoDecoderRenderer.m` - 增强的视频尺寸计算
- `VoidLink/ViewControllers/SettingsViewController.h/m` - 新增设置UI
- `VoidLink/ViewControllers/StreamFrameViewController.m` - 适配逻辑实现
- `VoidLink/ViewControllers/MainFrameViewController.h/m` - 重启流程支持