### PR TITLE
🍎 iOS 26.0+ 主菜单系统集成 (Main Menu System Integration)

### DIFF
--- a/VoidLink/AppDelegate.h
+++ b/VoidLink/AppDelegate.h
@@ -7,12 +7,22 @@
 //
 
 #import <UIKit/UIKit.h>
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 260000
+#import <UIKit/UIMainMenuSystem.h>
+#import <UIKit/UIMenuBuilder.h>
+#import <UIKit/UIMenu.h>
+#import <UIKit/UIAction.h>
+#endif
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 @property (strong, nonatomic) NSString *pcUuidToLoad;
 @property (strong, nonatomic) void (^shortcutCompletionHandler)(BOOL);
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 260000
+@property (nonatomic, copy) void(^mainMenuBuildHandler)(id<UIMenuBuilder> builder) API_AVAILABLE(ios(26.0));
+#endif
 
 @property (readonly, strong, nonatomic) NSManagedObjectContext *managedObjectContext;
 @property (readonly, strong, nonatomic) NSManagedObjectModel *managedObjectModel;

--- a/VoidLink/AppDelegate.m
+++ b/VoidLink/AppDelegate.m
@@ -60,7 +60,15 @@ static NSString* DB_NAME = @"Limelight_iOS.sqlite";
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for command tool customization after application launch (works only when user default is nil)
     [CommandManager presetDefaultCommands];
-    
+
+    // Configure UIMainMenuSystem for iOS 26.0+
+    if (@available(iOS 26.0, *)) {
+        // Reset streaming state on app launch
+        [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"VLIsCurrentlyStreaming"];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        [self setupMainMenuSystem];
+    }
+
     // For iOS 12 and below, we need to manually create the window
     if (@available(iOS 13.0, *)) {
         // Scene delegate will handle window creation
@@ -262,5 +270,110 @@ static NSString* DB_NAME = @"Limelight_iOS.sqlite";
     return [[self applicationDocumentsDirectory] URLByAppendingPathComponent:DB_NAME];
 #endif
 }
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 260000
+- (void)setupMainMenuSystem API_AVAILABLE(ios(26.0)) {
+    // Only setup main menu system on iPad where it makes sense
+    if (UIDevice.currentDevice.userInterfaceIdiom != UIUserInterfaceIdiomPad) {
+        return;
+    }
+
+    UIMainMenuSystem *mainMenu = [UIMainMenuSystem sharedSystem];
+
+    // Create configuration with default settings
+    UIMainMenuSystemConfiguration *config = [[UIMainMenuSystemConfiguration alloc] init];
+
+    // Set preferences for menu elements
+    config.newScenePreference = UIMenuSystemElementGroupPreferenceAutomatic;
+    config.documentPreference = UIMenuSystemElementGroupPreferenceAutomatic;
+    config.printingPreference = UIMenuSystemElementGroupPreferenceAutomatic;
+    config.findingPreference = UIMenuSystemElementGroupPreferenceAutomatic;
+    config.toolbarPreference = UIMenuSystemElementGroupPreferenceAutomatic;
+    config.sidebarPreference = UIMenuSystemElementGroupPreferenceAutomatic;
+    config.inspectorPreference = UIMenuSystemElementGroupPreferenceAutomatic;
+    config.textFormattingPreference = UIMenuSystemElementGroupPreferenceAutomatic;
+
+    // Save the build handler for later use with setNeedsRebuild
+    __weak typeof(self) weakSelf = self;
+    self.mainMenuBuildHandler = ^(id<UIMenuBuilder> builder) {
+        [weakSelf buildMainMenuWithBuilder:builder];
+    };
+
+    [mainMenu setBuildConfiguration:config buildHandler:self.mainMenuBuildHandler];
+
+    // Listen for streaming state changes to rebuild menu dynamically
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(streamingStateChanged:)
+                                                 name:@"VLStreamingStateChanged"
+                                               object:nil];
+}
+
+- (void)buildMainMenuWithBuilder:(id<UIMenuBuilder>)builder API_AVAILABLE(ios(26.0)) {
+    // Create Settings menu action
+    UIAction *settingsAction = [UIAction actionWithTitle:@"Settings"
+                                                    image:[UIImage systemImageNamed:@"sidebar.left"]
+                                               identifier:nil
+                                                  handler:^(__kindof UIAction * _Nonnull action) {
+            [self showSettingsFromMainMenu:action];
+        }];
+
+    // Create Settings menu
+    UIMenu *settingsMenu = [UIMenu menuWithTitle:@"Settings"
+                                            image:[UIImage systemImageNamed:@"sidebar.left"]
+                                       identifier:@"com.voidlink.settings"
+                                          options:UIMenuOptionsDisplayInline
+                                         children:@[settingsAction]];
+
+    // Create Toolbox menu action
+    UIAction *toolboxAction = [UIAction actionWithTitle:@"Toolbox"
+                                                   image:[UIImage systemImageNamed:@"wrench.and.screwdriver"]
+                                              identifier:@"com.voidlink.toolbox.action"
+                                                 handler:^(__kindof UIAction * _Nonnull action) {
+            [self showToolboxFromMainMenu:action];
+        }];
+
+    // Hide toolbox menu when not streaming
+    if (![self isCurrentlyStreaming]) {
+        toolboxAction.attributes = UIMenuElementAttributesHidden;
+    }
+
+    // Create Toolbox menu
+    UIMenu *toolboxMenu = [UIMenu menuWithTitle:@"Toolbox"
+                                           image:[UIImage systemImageNamed:@"wrench.and.screwdriver"]
+                                      identifier:@"com.voidlink.toolbox"
+                                         options:UIMenuOptionsDisplayInline
+                                        children:@[toolboxAction]];
+
+    // Insert menus after the View menu
+    [builder insertSiblingMenu:settingsMenu afterMenuForIdentifier:UIMenuView];
+    [builder insertSiblingMenu:toolboxMenu afterMenuForIdentifier:settingsMenu.identifier];
+}
+
+- (BOOL)isCurrentlyStreaming API_AVAILABLE(ios(26.0)) {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"VLIsCurrentlyStreaming"];
+}
+
+
+- (void)showSettingsFromMainMenu:(UIAction *)sender API_AVAILABLE(ios(26.0)) {
+    // Post notification to show settings
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"VLShowSettingsFromMainMenu"
+                                                        object:self
+                                                      userInfo:nil];
+}
+
+- (void)showToolboxFromMainMenu:(UIAction *)sender API_AVAILABLE(ios(26.0)) {
+    // Check if we're in stream state before showing toolbox
+    if ([self isCurrentlyStreaming]) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"VLShowToolboxFromMainMenu"
+                                                            object:self
+                                                          userInfo:nil];
+    }
+}
+
+- (void)streamingStateChanged:(NSNotification *)notification API_AVAILABLE(ios(26.0)) {
+    // Trigger menu rebuild when streaming state changes
+    [[UIMainMenuSystem sharedSystem] setNeedsRebuild];
+}
+#endif
 
 @end

--- a/VoidLink/ViewControllers/MainFrameViewController.m
+++ b/VoidLink/ViewControllers/MainFrameViewController.m
@@ -85,6 +85,11 @@
 }
 static NSMutableSet* hostList;
 
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLShowSettingsFromMainMenu" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLShowToolboxFromMainMenu" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLShowToolboxRequested" object:nil];
+}
 - (void)startPairing:(NSString *)PIN {
     // Needs to be synchronous to ensure the alert is shown before any potential
     // failure callback could be invoked.
@@ -1400,6 +1405,7 @@ static NSMutableSet* hostList;
     return barItem;
 }
 
+
 - (void)helpButtonTapped{
     if (@available(iOS 13.0, *)) {
         AboutViewController *aboutVC = [[AboutViewController alloc] init];
@@ -1409,6 +1415,7 @@ static NSMutableSet* hostList;
         // Fallback on earlier versions
     }
 }
+
 
 - (CGFloat)getStandardNavBarHeight{
     return [self isIPhone] ? UINavigationBarHeightIPhone : UINavigationBarHeightIPad;
@@ -1534,7 +1541,11 @@ static NSMutableSet* hostList;
     DataManager* dataMan = [[DataManager alloc] init];
     TemporarySettings* tempSettings = [dataMan getSettings];
     [ThemeManager setUserInterfaceStyle:tempSettings.appTheme.intValue];
-    
+
+    // Listen for main menu system notifications (iOS 26.0+)
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showSettingsFromMainMenu:) name:@"VLShowSettingsFromMainMenu" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showToolboxFromMainMenu:) name:@"VLShowToolboxFromMainMenu" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleShowToolboxRequest:) name:@"VLShowToolboxRequested" object:nil];
 #if !TARGET_OS_TV
     self.settingsExpandedInStreamView = false; // init this flag
     self.revealViewController.isStreaming = false; //init this flag for rvlVC
@@ -2294,6 +2305,35 @@ static NSMutableSet* hostList;
     // 通知子控制器已添加完成
     [self.hostCollectionVC didMoveToParentViewController:self];
 
+}
+
+#pragma mark - Main Menu System Notification Handlers
+
+- (void)showSettingsFromMainMenu:(NSNotification *)notification {
+    // Handle settings menu request from UIMainMenuSystem (iOS 26.0+)
+    // Only open settings if it's not already open
+    if (currentPosition != FrontViewPositionLeft) {
+        [[self revealViewController] revealToggleAnimated:YES];
+    }
+}
+
+- (void)showToolboxFromMainMenu:(NSNotification *)notification {
+    // Handle toolbox menu request from UIMainMenuSystem (iOS 26.0+)
+    [self handleShowToolboxRequest:notification];
+}
+
+- (void)handleShowToolboxRequest:(NSNotification *)notification {
+    // Handle toolbox request from other parts of the app
+    // Find and notify current StreamFrameViewController to show toolbox
+    if ([self.revealViewController.frontViewController isKindOfClass:[StreamFrameViewController class]]) {
+        StreamFrameViewController *streamVC = (StreamFrameViewController *)self.revealViewController.frontViewController;
+        [streamVC bringUpToolboxMenu];
+    } else {
+        // Otherwise, post notification for StreamFrameViewController to handle
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"VLShowToolboxRequested"
+                                                            object:self
+                                                          userInfo:nil];
+    }
 }
 
 @end

--- a/VoidLink/ViewControllers/StreamFrameViewController.m
+++ b/VoidLink/ViewControllers/StreamFrameViewController.m
@@ -365,6 +365,16 @@
     if(viewIsBeingResized) viewIsBeingResized = false;
     else [self configOscLayoutTool];
     [self updateToolboxSpecialEntries];
+    // Listen for main menu system notifications (iOS 26.0+)
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleShowToolboxRequest:) name:@"VLShowToolboxRequested" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showToolboxFromMainMenu:) name:@"VLShowToolboxFromMainMenu" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(showSettingsFromMainMenu:) name:@"VLShowSettingsFromMainMenu" object:nil];
+
+    // Notify about streaming state changes for UIMainMenuSystem
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"VLIsCurrentlyStreaming"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"VLStreamingStateChanged" object:self];
+
     [self configGestures];
     [self configZoomGestureAndAddStreamView];
     [self->_streamView disableOnScreenControls]; //don't know why but this must be called outside the streamview class, just put it here. execute in streamview class cause hang
@@ -938,14 +948,19 @@
 
     [_statsUpdateTimer invalidate];
     _statsUpdateTimer = nil;
-    
+
     [self.navigationController popToRootViewControllerAnimated:NO];
-    
+
     _extWindow = nil;
-    
+
     if(_streamConfig.redirectMic) [micHandler stopTappingWithStopEngine:true];
 
     self.mainFrameViewcontroller.settingsExpandedInStreamView = false; // reset this flag to false
+
+    // Reset streaming state for UIMainMenuSystem
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"VLIsCurrentlyStreaming"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"VLStreamingStateChanged" object:self];
 }
 
 // External Screen connected
@@ -1648,6 +1663,16 @@
 
 - (void)dealloc {
     [self stopDisplayLink];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLMenuBarOpenSettings" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLMenuBarOpenToolbox" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLShowToolboxRequested" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLShowToolboxFromMainMenu" object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"VLShowSettingsFromMainMenu" object:nil];
+
+    // Notify about streaming state changes for UIMainMenuSystem
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"VLIsCurrentlyStreaming"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"VLStreamingStateChanged" object:self];
 }
 
 - (void)setupDisplayLink {
@@ -1672,4 +1697,23 @@
 }
 
 
+
+#pragma mark - Main Menu System Notification Handlers
+
+- (void)handleShowToolboxRequest:(NSNotification *)notification {
+    // Handle toolbox request from MainFrameViewController
+    [self bringUpToolboxMenu];
+}
+
+- (void)showToolboxFromMainMenu:(NSNotification *)notification {
+    // Handle toolbox menu request from UIMainMenuSystem (iOS 26.0+)
+    [self bringUpToolboxMenu];
+}
+
+- (void)showSettingsFromMainMenu:(NSNotification *)notification {
+    // Handle settings menu request from UIMainMenuSystem (iOS 26.0+)
+    [self expandSettingsView];
+}
+
+// removed old in-place restart path (scheduleAutoAdaptRestartWithDelay / performAutoAdaptRestart)
 @end


### PR DESCRIPTION
## 🍎 iOS 26.0+ 主菜单系统集成 (Main Menu System Integration)

### 📝 功能概述
为 VoidLink 应用添加对 iOS 26.0+ 新增的 UIMainMenuSystem 框架的支持，在 iPad 上提供原生主菜单体验。

### ✨ 主要特性

#### 🎯 **动态菜单系统**
- **设置菜单**: 快速访问应用设置侧边栏
- **工具箱菜单**: 仅在流媒体传输时显示，提供实时工具访问
- **智能显示**: 工具箱菜单根据流媒体状态动态显示/隐藏

#### 🔄 **状态感知**
- **实时状态同步**: 基于当前流媒体状态自动重建菜单
- **状态持久化**: 使用 NSUserDefaults 跟踪流媒体状态
- **通知驱动**: 通过通知系统实现组件间状态同步

### 🔧 技术实现

#### **核心组件**
- AppDelegate: 主菜单系统初始化和配置
- MainFrameViewController: 设置菜单处理和工具箱请求路由
- StreamFrameViewController: 流媒体状态管理和工具箱显示

#### **关键方法**
- setupMainMenuSystem: 系统配置和菜单构建
- buildMainMenuWithBuilder: 动态菜单创建
- streamingStateChanged: 状态变化响应

#### **通知架构**
- VLStreamingStateChanged: 流媒体状态变化通知
- VLShowSettingsFromMainMenu: 设置菜单请求
- VLShowToolboxFromMainMenu: 工具箱菜单请求