### PR TITLE
feat: add haptics support for kishi v3 pro XL

### DIFF
--- a/VoidLink.xcodeproj/project.pbxproj
+++ b/VoidLink.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		18729EDE2E8BD68800101194 /* UUIDHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18729EDD2E8BD68800101194 /* UUIDHelper.swift */; };
 		18780CC72F10D66000B90483 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18780CC62F10D66000B90483 /* StoreKit.framework */; };
 		A76B00032FFCC00100000003 /* GameSirG8MFiRumbler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76B00022FFCC00100000002 /* GameSirG8MFiRumbler.swift */; };
+		B76B00032FFCC00100000003 /* KishiV3ProXLRumbler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76B00022FFCC00100000002 /* KishiV3ProXLRumbler.swift */; };
 		A76B00052FFCC00100000005 /* ExternalAccessory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A76B00042FFCC00100000004 /* ExternalAccessory.framework */; };
 		18780CCA2F10D6CC00B90483 /* IAPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18780CC92F10D6CC00B90483 /* IAPManager.swift */; };
 		187F4B282E04658A00EECC59 /* WidgetPanelStackView.m in Sources */ = {isa = PBXBuildFile; fileRef = 187F4B272E04658A00EECC59 /* WidgetPanelStackView.m */; };
@@ -203,6 +204,7 @@
 		18729EDD2E8BD68800101194 /* UUIDHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUIDHelper.swift; sourceTree = "<group>"; };
 		18780CC62F10D66000B90483 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		A76B00022FFCC00100000002 /* GameSirG8MFiRumbler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GameSirG8MFiRumbler.swift; sourceTree = "<group>"; };
+		B76B00022FFCC00100000002 /* KishiV3ProXLRumbler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KishiV3ProXLRumbler.swift; sourceTree = "<group>"; };
 		A76B00042FFCC00100000004 /* ExternalAccessory.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ExternalAccessory.framework; path = System/Library/Frameworks/ExternalAccessory.framework; sourceTree = SDKROOT; };
 		18780CC92F10D6CC00B90483 /* IAPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPManager.swift; sourceTree = "<group>"; };
 		187F4B232E04633100EECC59 /* WidgetPanelStackView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WidgetPanelStackView.h; sourceTree = "<group>"; };
@@ -757,6 +759,7 @@
 			children = (
 				84351B052C29ACAF00A77989 /* CustomOSC */,
 				A76B00022FFCC00100000002 /* GameSirG8MFiRumbler.swift */,
+				B76B00022FFCC00100000002 /* KishiV3ProXLRumbler.swift */,
 				FB89460A19F646E200339C8A /* ControllerSupport.h */,
 				FB89460B19F646E200339C8A /* ControllerSupport.m */,
 				FB89460C19F646E200339C8A /* StreamView.h */,
@@ -1251,6 +1254,7 @@
 				FB6549561A57907E001C8F39 /* DiscoveryWorker.m in Sources */,
 				84351B0E2C29ACCB00A77989 /* LayoutOnScreenControls.m in Sources */,
 				A76B00032FFCC00100000003 /* GameSirG8MFiRumbler.swift in Sources */,
+				B76B00032FFCC00100000003 /* KishiV3ProXLRumbler.swift in Sources */,
 				FB89462A19F646E200339C8A /* ControllerSupport.m in Sources */,
 				FB9AFD3D1A7E111600872C98 /* AppAssetResponse.m in Sources */,
 				1888C1922E24C33100108730 /* AboutViewController.swift in Sources */,

--- a/VoidLink/Input/ControllerSupport.m
+++ b/VoidLink/Input/ControllerSupport.m
@@ -120,6 +120,7 @@ static void ApplyAdaptiveTriggerEffect(GCDualSenseAdaptiveTrigger* trigger,
     OSCProfilesManager* oscProfileMan;
 #if !TARGET_OS_TV
     GameSirG8MFiRumbler *_gameSirG8MFiRumbler;
+    KishiV3ProXLRumbler *_kishiRumbler;
 #endif
 
 #define EMULATING_SELECT     0x1
@@ -161,6 +162,10 @@ static void ApplyAdaptiveTriggerEffect(GCDualSenseAdaptiveTrigger* trigger,
 -(void) applyPhysicalControllerRumble:(VoidController*)controller lowFreqMotor:(unsigned short)lowFreqMotor highFreqMotor:(unsigned short)highFreqMotor
 {
 #if !TARGET_OS_TV
+    if ([_kishiRumbler isTargetController:controller.gamepad]) {
+        [_kishiRumbler setLowFrequencyMotor:lowFreqMotor highFrequencyMotor:highFreqMotor];
+        return;
+    }
     if (controller.hardware == ControllerHardwareG8PlusMFi) {
         // NSLog(@"[G8Rumble] route native rumble low=%hu high=%hu", lowFreqMotor, highFreqMotor);
         [_gameSirG8MFiRumbler setLowFrequencyMotor:lowFreqMotor highFrequencyMotor:highFreqMotor];
@@ -1212,6 +1217,11 @@ static void ApplyAdaptiveTriggerEffect(GCDualSenseAdaptiveTrigger* trigger,
                 }
             }
                         
+#if !TARGET_OS_TV
+            if ([_kishiRumbler isTargetController:controller]) {
+                capabilities |= LI_CCAP_RUMBLE;
+            }
+#endif
             // Detect supported haptics localities
             if (controller.haptics) {
                 if ([controller.haptics.supportedLocalities containsObject:GCHapticsLocalityHandles]) {
@@ -2039,6 +2049,7 @@ double rc_expo(double x, double expo) {
     _controllerNumbers = 0;
 #if !TARGET_OS_TV
     _gameSirG8MFiRumbler = [[GameSirG8MFiRumbler alloc] init];
+    _kishiRumbler = [[KishiV3ProXLRumbler alloc] init];
 #endif
     
     _captureMouse = (streamConfig.localMousePointerMode == 0);
@@ -2100,6 +2111,9 @@ double rc_expo(double x, double expo) {
         VoidController* voidController = [self->_voidControllers objectForKey:[NSNumber numberWithInteger:controller.playerIndex]];
         if (voidController) {
 #if !TARGET_OS_TV
+            if ([self->_kishiRumbler isTargetController:controller]) {
+                [self->_kishiRumbler stopAndClose];
+            }
             if ([self->_gameSirG8MFiRumbler isTargetController:controller]) {
                 [self->_gameSirG8MFiRumbler stopAndClose];
             }
@@ -2309,6 +2323,7 @@ double rc_expo(double x, double expo) {
     [ControllerUtil stopAllDualSenseHaptics];
 #if !TARGET_OS_TV
     [_gameSirG8MFiRumbler invalidate];
+    [_kishiRumbler invalidate];
 #endif
 
     if (VLSharedControllerSupport == self) {

--- a/VoidLink/Input/KishiV3ProXLRumbler.swift
+++ b/VoidLink/Input/KishiV3ProXLRumbler.swift
@@ -1,0 +1,222 @@
+import ExternalAccessory
+import Foundation
+import GameController
+import UIKit
+
+/// Verified on RZ06-0547 firmware 1.01.000 using com.razer.kishicontrollerv2.
+/// Uses legacy two-motor commands, not Apple's GCController haptics engine.
+@objcMembers
+final class KishiV3ProXLRumbler: NSObject, StreamDelegate {
+    private static let accessoryProtocol = "com.razer.kishicontrollerv2"
+    private var session: EASession?
+    private var packet: Data?
+    private var offset = 0
+    private var queued: Data?
+    private var lastSent: Data?
+    private var transaction: UInt8 = 0x17
+    private var active = true
+    private var stopping = false
+    private var closeTimer: Timer?
+    private var incoming = Data()
+    // Bound the cross-thread queue to one latest request, too.
+    private let lock = NSLock()
+    private var latest: (UInt16, UInt16)?
+    private var deliveryScheduled = false
+    private var invalidated = false
+
+    override init() {
+        super.init()
+        active = UIApplication.shared.applicationState == .active
+        let center = NotificationCenter.default
+        center.addObserver(self, selector: #selector(resignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        center.addObserver(self, selector: #selector(becomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        center.addObserver(self, selector: #selector(disconnected(_:)), name: .EAAccessoryDidDisconnect, object: nil)
+        center.addObserver(self, selector: #selector(connected), name: .EAAccessoryDidConnect, object: nil)
+        EAAccessoryManager.shared().registerForLocalNotifications()
+    }
+
+    deinit { NotificationCenter.default.removeObserver(self) }
+
+    func isTargetController(_ controller: GCController) -> Bool {
+        controller.vendorName?.caseInsensitiveCompare("Razer Kishi V3 Pro XL") == .orderedSame
+    }
+
+    private func accessory() -> EAAccessory? {
+        let matches = EAAccessoryManager.shared().connectedAccessories.filter {
+            $0.isConnected && $0.modelNumber == "RZ06-0547" &&
+            $0.manufacturer.caseInsensitiveCompare("Razer") == .orderedSame &&
+            $0.protocolStrings.contains(Self.accessoryProtocol)
+        }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    @objc(setLowFrequencyMotor:highFrequencyMotor:)
+    func setLowFrequencyMotor(_ low: UInt16, highFrequencyMotor high: UInt16) {
+        lock.lock()
+        guard !invalidated else { lock.unlock(); return }
+        latest = (low, high)
+        let schedule = !deliveryScheduled
+        deliveryScheduled = true
+        lock.unlock()
+        if schedule {
+            DispatchQueue.main.async { [self] in
+                lock.lock()
+                let value = invalidated ? nil : latest
+                latest = nil
+                deliveryScheduled = false
+                lock.unlock()
+                guard active, !stopping, let value else { return }
+                let data = Self.motorPayload(low: value.0, high: value.1)
+                if data == lastSent && queued == nil && packet == nil { return }
+                queued = data
+                if openSession() { flush() }
+            }
+        }
+    }
+
+    /// 7 zero bits + 8 zero bits + left8 + right8 + padding bit,
+    /// wrapped as Nexus chunk 1 with 64 data bytes. Stop is both zero.
+    static func motorPayload(low: UInt16, high: UInt16) -> Data {
+        let left = UInt8((UInt32(low) * 255 + 32767) / 65535)
+        let right = UInt8((UInt32(high) * 255 + 32767) / 65535)
+        return Data([1, 0, left >> 7, (left << 1) | (right >> 7), right << 1] + [UInt8](repeating: 0, count: 60))
+    }
+
+    static func frame(payload: Data, transaction: UInt8) -> Data {
+        precondition(payload.count == 65)
+        var bytes: [UInt8] = [0, transaction, 0, 75, 0, 65, 0x16, 0x0E]
+        bytes += payload
+        bytes += [bytes.dropFirst(2).reduce(0, ^), 0]
+        return Data(bytes)
+    }
+
+    private func openSession() -> Bool {
+        if session != nil { return true }
+        guard let device = accessory(),
+              let created = EASession(accessory: device, forProtocol: Self.accessoryProtocol),
+              let input = created.inputStream, let output = created.outputStream else { return false }
+        session = created
+        NSLog("[KishiRumble] opening %@", device.name)
+        for stream in [input as Stream, output as Stream] {
+            stream.delegate = self
+            stream.schedule(in: .main, forMode: .common)
+            stream.open()
+        }
+        return true
+    }
+
+    private func flush() {
+        guard let output = session?.outputStream, output.streamStatus == .open else { return }
+        while output.hasSpaceAvailable {
+            if packet == nil {
+                guard let data = queued else {
+                    if stopping { closeSession() }
+                    return
+                }
+                queued = nil
+                transaction &+= 1
+                packet = Self.frame(payload: data, transaction: transaction)
+                offset = 0
+            }
+            guard let bytes = packet else { return }
+            let written = bytes.withUnsafeBytes {
+                output.write($0.bindMemory(to: UInt8.self).baseAddress!.advanced(by: offset), maxLength: bytes.count - offset)
+            }
+            if written < 0 {
+                NSLog("[KishiRumble] write error: %@", String(describing: output.streamError))
+                closeSession()
+                return
+            }
+            if written == 0 { return }
+            offset += written
+            if offset == bytes.count {
+                lastSent = bytes.subdata(in: 8..<73)
+                packet = nil
+                offset = 0
+            }
+        }
+        if stopping && packet == nil && queued == nil { closeSession() }
+    }
+
+    func stopAndClose() {
+        // Retain until the stop has had a chance to reach the stream.
+        DispatchQueue.main.async { [self] in
+            lock.lock(); latest = nil; lock.unlock()
+            guard session != nil else { return }
+            stopping = true
+            queued = Self.motorPayload(low: 0, high: 0)
+            closeTimer?.invalidate()
+            closeTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { [self] _ in
+                if packet != nil || queued != nil { NSLog("[KishiRumble] stop write incomplete before close") }
+                closeSession()
+            }
+            flush()
+        }
+    }
+
+    func invalidate() {
+        lock.lock(); invalidated = true; latest = nil; lock.unlock()
+        stopAndClose()
+    }
+
+    @objc private func resignActive() { active = false; stopAndClose() }
+    @objc private func becomeActive() { active = true }
+    @objc private func connected() {
+        // GCController can arrive before ExternalAccessory. Retry only the latest
+        // request received while waiting, never rumble saved from a disconnection.
+        guard active, !stopping, queued != nil else { return }
+        lock.lock(); let allowed = !invalidated; lock.unlock()
+        if allowed && openSession() { flush() }
+    }
+
+    @objc private func disconnected(_ notification: Notification) {
+        guard let device = notification.userInfo?[EAAccessoryKey] as? EAAccessory,
+              device.connectionID == session?.accessory?.connectionID else { return }
+        closeSession()
+    }
+
+    private func closeSession() {
+        closeTimer?.invalidate(); closeTimer = nil
+        if let session {
+            for stream in [session.inputStream as Stream?, session.outputStream as Stream?].compactMap({ $0 }) {
+                stream.close(); stream.remove(from: .main, forMode: .common); stream.delegate = nil
+            }
+        }
+        session = nil; packet = nil; queued = nil; lastSent = nil
+        incoming.removeAll(); offset = 0; stopping = false
+    }
+
+    func stream(_ stream: Stream, handle eventCode: Stream.Event) {
+        guard let session, stream === session.inputStream || stream === session.outputStream else { return }
+        switch eventCode {
+        case .openCompleted, .hasSpaceAvailable: flush()
+        case .hasBytesAvailable:
+            guard let input = session.inputStream else { return }
+            var buffer = [UInt8](repeating: 0, count: 512)
+            while input.hasBytesAvailable {
+                let count = input.read(&buffer, maxLength: buffer.count)
+                if count < 0 { closeSession(); return }
+                if count == 0 { break }
+                incoming.append(contentsOf: buffer.prefix(count))
+                if incoming.count > 8192 { closeSession(); return }
+            }
+            // EA is a byte stream: replies may be fragmented or combined.
+            while incoming.count >= 10 {
+                let bytes = [UInt8](incoming)
+                let length = Int(bytes[2]) * 256 + Int(bytes[3])
+                guard length >= 10 && length <= 265 else { closeSession(); return }
+                guard bytes.count >= length else { return }
+                let reply = Array(bytes.prefix(length))
+                if reply[0] != 2 || reply[6] != 0x16 || reply[7] != 0x0E ||
+                    Int(reply[5]) != length - 10 || reply[length - 1] != 0 ||
+                    reply[2..<length - 2].reduce(0, ^) != reply[length - 2] {
+                    NSLog("[KishiRumble] rejected or malformed reply, status=%u", reply[0])
+                    lastSent = nil
+                }
+                incoming.removeFirst(length)
+            }
+        case .errorOccurred, .endEncountered: stopAndClose()
+        default: break
+        }
+    }
+}

--- a/VoidLink/Limelight-Info.plist
+++ b/VoidLink/Limelight-Info.plist
@@ -119,6 +119,7 @@ VoidLink uses microphone to stream your voice to PC host. Microphone redirection
 	<key>UISupportedExternalAccessoryProtocols</key>
 	<array>
 		<string>com.xiaoji.M2boot</string>
+		<string>com.razer.kishicontrollerv2</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
Adds Razer Kishi V3 Pro XL rumble support on iPad through its ExternalAccessory protocol, even when GCController.haptics is unavailable. The implementation is very similar to the recently added support for Gamesir G8+ MFI (https://github.com/The-Fried-Fish/VoidLink-previously-moonlight-zwm/pull/214), but using events specific to the Kishi.

- Advertises rumble support and maps host low/high motor strengths to  independent left/right legacy rumble commands.
- Coalesces pending updates, handles partial writes, and processes replies.
- Handles accessory reconnection and attempts to stop motors on stream  cleanup or app inactivity.

The way I built this was: first I built a custom app that I installed on my iPad to debug,identify and trigger the rumble events via the ExternalAccessory protocol. Once all events were working properly, I moved into VoidLink to add the controller support, built it and tested on my iPad


Validation:
- Full unsigned iPad build passed.
- Diagnostic testing on an iPad Pro M4 confirmed left/right/both motors  and distinct 25% and 100% strengths on  controller firmware 1.01.000. Played Hades 2 game via a vibeshine stream and haptics worked as expected